### PR TITLE
App::pherkin instead of App::Pherkin

### DIFF
--- a/lib/Test/BDD/Cucumber.pm
+++ b/lib/Test/BDD/Cucumber.pm
@@ -34,7 +34,7 @@ reading our short and crunchy L<Tutorial|Test::BDD::Cucumber::Manual::Tutorial>.
 If you B<already understand Cucumber>, and just want to get started then you
 should read the L<Step-writing quick-start
 guide|Test::BDD::Cucumber::Manual::Steps>, the documentation for our
-command-line tool L<App::Pherkin>, and L<How to integrate with
+command-line tool L<App::pherkin>, and L<How to integrate with
 Test::Builder|Test::BDD::Cucumber::Manual::Integration>.
 
 If you B<want to extend or integrated Test::BDD::Cucumber> then you'd probably


### PR DESCRIPTION
This fixed a small POD typo that rendered the link non-working.

You posted[1] on having a lot of bug reports, so I checked the dist and found another _very very small_ one, so I figured "why not?"

Still, good job on the whole thing! :)

[1] http://blogs.perl.org/users/peter_sergeant/2012/03/perl-and-cucumber.html
