### PR TITLE
Disable ANSI colours if we're not outputting to a terminal

### DIFF
--- a/bin/pherkin
+++ b/bin/pherkin
@@ -45,6 +45,10 @@ use strict;
 use warnings;
 use FindBin::libs;
 
+if ( not -t STDOUT ) {
+    $ENV{'ANSI_COLORS_DISABLED'} = 1;
+}
+
 use App::pherkin;
 my $result = App::pherkin->run( @ARGV );
 


### PR DESCRIPTION
Term::ANSIColor provides a handy ENV var we can turn on to stop this.
