### PR TITLE
Ever noticed how much typing stuff over and over again sucks?

### DIFF
--- a/examples/digest/features/step_definitions/basic_steps.pl
+++ b/examples/digest/features/step_definitions/basic_steps.pl
@@ -5,26 +5,27 @@ use warnings;
 
 use Digest;
 use Test::More;
-use Test::BDD::Cucumber::StepFile;
-use Method::Signatures;
 
-Given qr/a usable "(\w+)" class/, func ($c) { use_ok( $1 ); };
-Given qr/a Digest (\S+) object/, func ($c) {
+use Test::BDD::Cucumber::StepFile;
+
+Given qr/a usable "(\w+)" class/, sub { use_ok( $1 ); };
+
+Given qr/a Digest (\S+) object/, sub {
     my $object = Digest->new($1);
     ok( $object, "Object created" );
-    $c->stash->{'scenario'}->{'object'} = $object;
+    S->{'object'} = $object;
 };
 
-When qr/I've added "(.+)" to the object/, func ($c) {
-    $c->stash->{'scenario'}->{'object'}->add( $1 );
+When qr/I've added "(.+)" to the object/, sub {
+    S->{'object'}->add( $1 );
 };
 
-When "I've added the following to the object", func ($c) {
-    $c->stash->{'scenario'}->{'object'}->add( $c->data );
+When "I've added the following to the object", sub {
+    S->{'object'}->add( C->data );
 };
 
-Then qr/the (.+) output is "(.+)"/, func ($c) {
+Then qr/the (.+) output is "(.+)"/, sub {
     my $method = {base64 => 'b64digest', 'hex' => 'hexdigest' }->{ $1 } ||
         do { fail("Unknown output type $1"); return };
-    is( $c->stash->{'scenario'}->{'object'}->$method, $2 );
+    is( S->{'object'}->$method, $2 );
 };

--- a/lib/Test/BDD/Cucumber/StepFile.pm
+++ b/lib/Test/BDD/Cucumber/StepFile.pm
@@ -8,10 +8,11 @@ Test::BDD::Cucumber::StepFile - Functions for creating and loading Step Definiti
 
 use strict;
 use warnings;
+use Carp qw/croak/;
 
 require Exporter;
 our @ISA = qw(Exporter);
-our @EXPORT = qw(Given When Then Step Transform Before After);
+our @EXPORT = qw(Given When Then Step Transform Before After C S);
 
 our @definitions;
 
@@ -75,6 +76,18 @@ sub Step      { push( @definitions, [ Step      => @_ ] ) }
 sub Transform { push( @definitions, [ Transform => @_ ] ) }
 sub Before    { push( @definitions, [ Before    => @_ ] ) }
 sub After     { push( @definitions, [ After     => @_ ] ) }
+
+=head2 C
+
+=head2 S
+
+Return the context and the Scenario stash, respectively, B<but only when called
+inside a step definition>.
+
+=cut
+
+sub S { croak "You can only call `S` inside a step definition" }
+sub C { croak "You can only call `C` inside a step definition" }
 
 =head2 load
 


### PR DESCRIPTION
Remove the need for Method::Signatures, and also endless repetition of $c->stash->{'scenario'} with two handy localized subs.

``` perl
Given "my step", sub {
    # Before
    my $c = shift;
    $c->stash->{'scenario'}->{'mything'} = $c->data;

    # After
    S->{'mything'} = C->data;
}
```

I went and did the digest steps as an example.

Thoughts?
