### PR TITLE
Adding Test::File::ShareDir to list of dependencies

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -25,5 +25,6 @@ Storable = 0
 Term::ANSIColor = 3.00
 Test::Builder = 0
 Test::Differences = 0
+Test::File::ShareDir = 0
 Test::More = 0
 YAML::Syck = 0


### PR DESCRIPTION
Installing `Test::BDD::Cucumber` with `cpanm` unfortunately fails since `Test::File::ShareDir` (which is merely needed for the `T:B:C` tests) isn't one of the dependencies.  One can test this with a clean perl installation, e.g.:

```
perlbrew install perl-5.20.0
perlbrew use perl-5.20.0
cpanm install Test::BDD::Cucumber
```

This change adds this dependency, although it's not strictly necessary for `T:B:C` to run correctly, since it only impacts the test suite.  Interestingly enough, `Dist::Zilla` brings `T:F:SD` along as a dependency, so it's possible that the missing dependency for `T:B:C` simply went unnoticed.

Hope this helps!

Cheers,

Paul
