### PR TITLE
Replacing string `eval` with block `eval`

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,7 @@ File::Slurp = 0
 FindBin::libs = 0
 Getopt::Long = 0
 JSON::MaybeXS = 0
+Module::Runtime = 0
 Moose = 0
 Ouch = 0
 Path::Class = 0

--- a/lib/App/pherkin.pm
+++ b/lib/App/pherkin.pm
@@ -35,6 +35,7 @@ using the default output harness.
 =cut
 
 use Test::BDD::Cucumber::Loader;
+use Module::Runtime qw(use_module);
 
 =head1 METHODS
 
@@ -61,7 +62,7 @@ sub run {
     );
     die "No feature files found" unless @features;
 
-    eval "require $options->{'harness'}" || die $@;
+    eval { use_module($options->{'harness'}) } || die $@;
     my $harness  = $options->{'harness'}->new();
     $harness->startup();
 

--- a/lib/Test/BDD/Cucumber/Harness/TermColor.pm
+++ b/lib/Test/BDD/Cucumber/Harness/TermColor.pm
@@ -29,7 +29,7 @@ BEGIN {
         (! $ENV{'DISABLE_WIN32_FALLBACK'} )
     ) {
         # Try and load
-        eval "require Win32::Console::ANSI";
+        eval { require Win32::Console::ANSI };
         if ( $@ ) {
             print "# Install Win32::Console::ANSI to display colors properly\n";
         }


### PR DESCRIPTION
This change is modelled on comments and recommendations from @shadowcat-mst
and this time should actually have executable code!  My apologies for the previous dodgy version.
