### PR TITLE
Adding --help command line option to `pherkin`

### DIFF
--- a/bin/pherkin
+++ b/bin/pherkin
@@ -35,6 +35,7 @@ is considered to be failing.
  -t, --tags ~@tag       Run scenarios tagged without '@tag'
  --i18n LANG            List keywords for a particular language.
                         '--i18n help' lists all languages available.
+ -h, --help             Print usage information.
 
 =head1 OUTPUTS
 

--- a/lib/App/pherkin.pm
+++ b/lib/App/pherkin.pm
@@ -7,6 +7,8 @@ use FindBin::libs;
 use Getopt::Long;
 use Module::Runtime qw(use_module);
 use List::Util qw(max);
+use Pod::Usage;
+use FindBin qw($Bin $RealBin $RealScript $Script);
 
 use Test::BDD::Cucumber::I18n qw(languages langdef readable_keywords keyword_to_subname);
 use Test::BDD::Cucumber::Loader;
@@ -104,7 +106,11 @@ sub _process_arguments {
         'b|blib'     => \(my $add_blib),
         'o|output=s' => \(my $harness),
 	't|tags=s@'  => \$tags,
-	'i18n=s'     => \(my $i18n)
+	'i18n=s'     => \(my $i18n),
+	'h|help'     => \&pod2usage(
+				-verbose => 1,
+				-input => "$RealBin/$Script",
+			    ),
     );
 
     if ($i18n) {


### PR DESCRIPTION
Now it's possible to run `pherkinn --help` which for some people feels more
natural than `perldoc bin/pherkin` (or similar).

Comments welcome :-)
