### PR TITLE
Fix a tiny typo in I18n.pm

### DIFF
--- a/lib/Test/BDD/Cucumber/I18n.pm
+++ b/lib/Test/BDD/Cucumber/I18n.pm
@@ -12,7 +12,7 @@ Internationalization of feature files and step definitions.
 
 =head1 SYNOPSIS
 
-  use Test::BDD::Cucumber::I18N
+  use Test::BDD::Cucumber::I18n
       qw(languages has_language langdef);
 
   # get codes of supported languages


### PR DESCRIPTION
The synopsis says "use Test::BDD::Cucumber::I18N" when it should be "use Test::BDD::Cucumber::I18n".
