### PR TITLE
Fix match mode and add tests

### DIFF
--- a/lib/App/pherkin.pm
+++ b/lib/App/pherkin.pm
@@ -513,7 +513,7 @@ sub _make_executor_match_only {
 
     for my $verb ( keys %{$executor->steps} ) {
         for my $step_tuple ( @{ $executor->steps->{$verb} } ) {
-            $step_tuple->[1] = $match_sub;
+            $step_tuple->[2] = $match_sub;
         }
     }
 

--- a/t/910_run_tests_pherkin.t
+++ b/t/910_run_tests_pherkin.t
@@ -1,0 +1,19 @@
+#!perl
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+
+use Test::More;
+
+use App::pherkin;
+use Test::CucumberExtensionMetadataVerify;
+
+my $pherkin = App::pherkin->new;
+push @{$pherkin->extensions}, Test::CucumberExtensionMetadataVerify->new;
+subtest 'Run pherkin in match-only mode', sub {
+    $pherkin->run('-oTestBuilder', '-m', 't/pherkin/match-only/');
+};
+
+done_testing;

--- a/t/lib/Test/CucumberExtensionMetadataVerify.pm
+++ b/t/lib/Test/CucumberExtensionMetadataVerify.pm
@@ -1,0 +1,37 @@
+#!perl
+
+package Test::CucumberExtensionMetadataVerify;
+
+# Extension to verify existence of metadata
+
+use Moo;
+use Carp;
+use Scalar::Util qw( reftype );
+
+use Test::BDD::Cucumber::Extension;
+extends 'Test::BDD::Cucumber::Extension';
+
+
+sub pre_step  {
+    my ($self, $step, $step_context) = @_;
+
+    croak 'pre_step called with incorrect number $step array elements'
+        if scalar(@$step) != 3;
+
+    croak 'pre_step called with incorrect first element type of $step array'
+        # 5.10 reports SCALAR where the argument actually is a regexp; ignore <=5.10
+        if reftype $step->[0] ne 'REGEXP' and $] ge '5.012';
+
+    croak 'pre_step called with incorrect second element type of $step array'
+        if reftype $step->[1] ne 'HASH';
+
+    croak 'pre_step called with incorrect meta data content in $step array'
+        if exists $step->[1]->{meta} and $step->[1]->{meta} ne 'data';
+
+    croak 'pre_step called with incorrect third element type of $step array'
+        if reftype $step->[2] ne 'CODE';
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/t/pherkin/match-only/match.feature
+++ b/t/pherkin/match-only/match.feature
@@ -1,0 +1,16 @@
+Feature: Match-only testing
+  As a test developer I want to be able to assert that
+  all steps in my feature are matched without being
+  required to run the entire test suite (and spend
+  the associated amount of time waiting).
+
+  As a solution to this problem, Pherkin offers the
+  ability to run through all steps in features matching
+  the steps without executing the step functions.
+
+
+  Scenario: Test match only function
+    Given a step with step function that calls die()
+     When there are further steps with associated step functions
+     Then I expect all steps to be matched
+

--- a/t/pherkin/match-only/step_definitions/match_steps.pl
+++ b/t/pherkin/match-only/step_definitions/match_steps.pl
@@ -1,0 +1,17 @@
+
+use strict;
+use warnings;
+
+use Test::BDD::Cucumber::StepFile;
+
+
+Given qr/^\Qa step with step function that calls die()\E$/, sub {
+    die "This step function calls die()";
+};
+
+When qr/^\Qthere are further steps with associated step functions\E$/, sub {
+};
+
+Then qr/^\QI expect all steps to be matched\E$/, { 'meta' => 'data' }, sub {
+};
+


### PR DESCRIPTION
The addition of meta data broke match mode. Add tests for match mode
as well as the interaction of it with step metadata.