### PR TITLE
Rename TBC::Harness::TestBuilder to TBC::Harness::TAP for consistency

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 -----
 0.61  [to be released]
+    - Renamed Test::BDD::Cucumber::Harness::TestBuilder to
+      Test::BDD::Cucumber::Harness::TAP for consistency with the
+      other harnesses (which have output-based names)
     - Added documentation of availability of meta data defined with step
       functions for use by extensions to the Architecture manual
 0.60  2019-08-31

--- a/bin/pherkin
+++ b/bin/pherkin
@@ -79,10 +79,10 @@ Help
 
 C<pherkin> can output using any of the C<Test::BDD::Cucumber::Harness> output
 modules. L<Test::BDD::Cucumber::TermColor> is the default, but
-L<Test::BDD::Cucumber::TestBuilder> is also a reasonable option:
+L<Test::BDD::Cucumber::TAP> is also a reasonable option:
 
   pherkin -o TermColor some/path/feature   # The default
-  pherkin -o TestBuilder some/path/feature # Test::Builder-type text output
+  pherkin -o TAP some/path/feature         # TAP output for e.g. prove
 
 =head1 CONFIGURATION PROFILES
 

--- a/lib/TAP/Parser/SourceHandler/Feature.pm
+++ b/lib/TAP/Parser/SourceHandler/Feature.pm
@@ -12,7 +12,7 @@ use TAP::Parser::Iterator::PherkinStream;
 use App::pherkin;
 
 use Test::BDD::Cucumber::Loader;
-use Test::BDD::Cucumber::Harness::TestBuilder;
+use Test::BDD::Cucumber::Harness::TAP;
 
 use Path::Class qw/file/;
 
@@ -90,7 +90,7 @@ sub make_iterator {
     }
 
     close $input_fh;
-    my $harness = Test::BDD::Cucumber::Harness::TestBuilder->new(
+    my $harness = Test::BDD::Cucumber::Harness::TAP->new(
         {   fail_skip    => 1,
             _tb_instance => $tb,
         }

--- a/lib/Test/BDD/Cucumber/Harness.pm
+++ b/lib/Test/BDD/Cucumber/Harness.pm
@@ -10,7 +10,7 @@ Harnesses allow your feature files to be executed while telling the outside
 world about how the testing is going, and what's being tested. This is a base
 class for creating new harnesses. You can see
 L<Test::BDD::Cucumber::Harness::TermColor> and
-L<Test::BDD::Cucumber::Harness::TestBuilder> for examples, although if you need
+L<Test::BDD::Cucumber::Harness::TAP> for examples, although if you need
 to interact with the results in a more exciting way, you'd be best off
 interacting with L<Test::BDD::Cucumber::Harness::Data>.
 

--- a/lib/Test/BDD/Cucumber/Harness/TAP.pm
+++ b/lib/Test/BDD/Cucumber/Harness/TAP.pm
@@ -1,0 +1,137 @@
+package Test::BDD::Cucumber::Harness::TAP;
+
+=head1 NAME
+
+Test::BDD::Cucumber::Harness::TAP - Generates output as TAP
+
+=head1 DESCRIPTION
+
+A L<Test::BDD::Cucumber::Harness> subclass whose output is
+TAP for consumption by e.g C<prove> or C<yath>.
+
+=head1 OPTIONS
+
+=head2 fail_skip
+
+Boolean - makes tests with no matcher fail
+
+=cut
+
+use strict;
+use warnings;
+use Moo;
+use Types::Standard qw( Bool InstanceOf );
+use Test::More;
+
+extends 'Test::BDD::Cucumber::Harness';
+has 'fail_skip' => ( is => 'rw', isa => Bool, default => 0 );
+has '_tb_instance' => ( is => 'rw', isa => InstanceOf['Test::Builder'] );
+
+my $li = ' ' x 7;
+my $ni = ' ' x 4;
+my $si = ' ' x 9;
+my $di = ' ' x 17;
+
+sub _tb {
+    my $self = shift;
+    return $self->_tb_instance || Test::Builder->new();
+}
+
+sub feature {
+    my ( $self, $feature ) = @_;
+    $self->_tb->note( "${li}Feature: " . $feature->name );
+    $self->_tb->note( "$li$ni" . $_->content )
+        for @{ $feature->satisfaction };
+    $self->_tb->note("");
+}
+
+sub scenario {
+    my ( $self, $scenario, $dataset ) = @_;
+    $self->_tb->note( "$li${ni}Scenario: " . ( $scenario->name || '' ) );
+}
+sub scenario_done { my $self = shift; $self->_tb->note(""); }
+
+sub step { }
+
+sub step_done {
+    my ( $self, $context, $result ) = @_;
+
+    my $status = $result->result;
+
+    my $step = $context->step;
+    my $step_name;
+
+    if ( $context->is_hook ) {
+        $status ne 'undefined'
+            and $status ne 'pending'
+            and $status ne 'passing'
+            or return;
+        $step_name = 'In ' . ucfirst( $context->verb ) . ' Hook';
+    } else {
+        $step_name
+            = $si . ucfirst( $step->verb_original ) . ' ' . $context->text;
+    }
+
+    if ( $status eq 'undefined' || $status eq 'pending' ) {
+        if ( $self->fail_skip ) {
+            if ( $status eq 'undefined' ) {
+                $self->_tb->ok( 0, "No matcher for: $step_name" );
+            } else {
+                $self->_tb->ok( 0,
+                    "Test skipped due to failure in previous step" );
+            }
+            $self->_note_step_data($step);
+        } else {
+        TODO: { $self->_tb->todo_skip( $step_name, 1 ) }
+            $self->_note_step_data($step);
+        }
+    } elsif ( $status eq 'passing' ) {
+        $self->_tb->ok( 1, $step_name );
+        $self->_note_step_data($step);
+    } else {
+        $self->_tb->ok( 0, $step_name );
+        $self->_note_step_data($step);
+        if ( !$context->is_hook ) {
+            my $step_location
+                = '  in step at '
+                . $step->line->document->filename
+                . ' line '
+                . $step->line->number . '.';
+            $self->_tb->diag($step_location);
+        }
+        $self->_tb->diag( $result->output );
+    }
+}
+
+sub _note_step_data {
+    my ( $self, $step ) = @_;
+    return unless $step;
+    my @step_data = @{ $step->data_as_strings };
+    return unless @step_data;
+
+    if ( ref( $step->data ) eq 'ARRAY' ) {
+        for (@step_data) {
+            $self->_tb->note( $di . $_ );
+        }
+    } else {
+        $self->_tb->note( $di . '"""' );
+        for (@step_data) {
+            $self->_tb->note( $di . '  ' . $_ );
+        }
+        $self->_tb->note( $di . '"""' );
+    }
+}
+
+sub shutdown { my $self = shift; $self->_tb->note( $self->_tb->done_testing() ); }
+
+=head1 AUTHOR
+
+Peter Sergeant C<pete@clueball.com>
+
+=head1 LICENSE
+
+Copyright 2011-2016, Peter Sergeant; Licensed under the same terms as Perl
+
+=cut
+
+1;

--- a/lib/Test/BDD/Cucumber/Harness/TestBuilder.pm
+++ b/lib/Test/BDD/Cucumber/Harness/TestBuilder.pm
@@ -2,136 +2,18 @@ package Test::BDD::Cucumber::Harness::TestBuilder;
 
 =head1 NAME
 
-Test::BDD::Cucumber::Harness::TestBuilder - Pipes step output via Test::Builder
+Test::BDD::Cucumber::Harness::TestBuilder - Temporary redirector to TAP harness
 
 =head1 DESCRIPTION
 
-A L<Test::BDD::Cucumber::Harness> subclass whose output is sent to
-L<Test::Builder>.
-
-=head1 OPTIONS
-
-=head2 fail_skip
-
-Boolean - makes tests with no matcher fail
 
 =cut
 
-use strict;
-use warnings;
+use Test::BDD::Cucumber::Harness::TAP;
+
 use Moo;
-use Types::Standard qw( Bool InstanceOf );
-use Test::More;
+extends 'Test::BDD::Cucumber::Harness::TAP';
 
-extends 'Test::BDD::Cucumber::Harness';
-has 'fail_skip' => ( is => 'rw', isa => Bool, default => 0 );
-has '_tb_instance' => ( is => 'rw', isa => InstanceOf['Test::Builder'] );
-
-my $li = ' ' x 7;
-my $ni = ' ' x 4;
-my $si = ' ' x 9;
-my $di = ' ' x 17;
-
-sub _tb {
-    my $self = shift;
-    return $self->_tb_instance || Test::Builder->new();
-}
-
-sub feature {
-    my ( $self, $feature ) = @_;
-    $self->_tb->note( "${li}Feature: " . $feature->name );
-    $self->_tb->note( "$li$ni" . $_->content )
-        for @{ $feature->satisfaction };
-    $self->_tb->note("");
-}
-
-sub scenario {
-    my ( $self, $scenario, $dataset ) = @_;
-    $self->_tb->note( "$li${ni}Scenario: " . ( $scenario->name || '' ) );
-}
-sub scenario_done { my $self = shift; $self->_tb->note(""); }
-
-sub step { }
-
-sub step_done {
-    my ( $self, $context, $result ) = @_;
-
-    my $status = $result->result;
-
-    my $step = $context->step;
-    my $step_name;
-
-    if ( $context->is_hook ) {
-        $status ne 'undefined'
-            and $status ne 'pending'
-            and $status ne 'passing'
-            or return;
-        $step_name = 'In ' . ucfirst( $context->verb ) . ' Hook';
-    } else {
-        $step_name
-            = $si . ucfirst( $step->verb_original ) . ' ' . $context->text;
-    }
-
-    if ( $status eq 'undefined' || $status eq 'pending' ) {
-        if ( $self->fail_skip ) {
-            if ( $status eq 'undefined' ) {
-                $self->_tb->ok( 0, "No matcher for: $step_name" );
-            } else {
-                $self->_tb->ok( 0,
-                    "Test skipped due to failure in previous step" );
-            }
-            $self->_note_step_data($step);
-        } else {
-        TODO: { $self->_tb->todo_skip( $step_name, 1 ) }
-            $self->_note_step_data($step);
-        }
-    } elsif ( $status eq 'passing' ) {
-        $self->_tb->ok( 1, $step_name );
-        $self->_note_step_data($step);
-    } else {
-        $self->_tb->ok( 0, $step_name );
-        $self->_note_step_data($step);
-        if ( !$context->is_hook ) {
-            my $step_location
-                = '  in step at '
-                . $step->line->document->filename
-                . ' line '
-                . $step->line->number . '.';
-            $self->_tb->diag($step_location);
-        }
-        $self->_tb->diag( $result->output );
-    }
-}
-
-sub _note_step_data {
-    my ( $self, $step ) = @_;
-    return unless $step;
-    my @step_data = @{ $step->data_as_strings };
-    return unless @step_data;
-
-    if ( ref( $step->data ) eq 'ARRAY' ) {
-        for (@step_data) {
-            $self->_tb->note( $di . $_ );
-        }
-    } else {
-        $self->_tb->note( $di . '"""' );
-        for (@step_data) {
-            $self->_tb->note( $di . '  ' . $_ );
-        }
-        $self->_tb->note( $di . '"""' );
-    }
-}
-
-sub shutdown { my $self = shift; $self->_tb->note( $self->_tb->done_testing() ); }
-
-=head1 AUTHOR
-
-Peter Sergeant C<pete@clueball.com>
-
-=head1 LICENSE
-
-Copyright 2011-2016, Peter Sergeant; Licensed under the same terms as Perl
-
-=cut
+warn __PACKAGE__ . ' has been renamed to Test::BDD::Cucumber::Harness::TAP; TestBuilder will be removed in 1.0';
 
 1;

--- a/lib/Test/BDD/Cucumber/Manual/Integration.pod
+++ b/lib/Test/BDD/Cucumber/Manual/Integration.pod
@@ -74,7 +74,7 @@ as generated from C<make test> after C<perl Makefile.PL>.
  use Test::BDD::Cucumber::Loader;
 
  # This harness prints out nice TAP
- use Test::BDD::Cucumber::Harness::TestBuilder;
+ use Test::BDD::Cucumber::Harness::TAP;
 
  # Load a directory with Cucumber files in it. It will recursively execute any
  # file matching .*_steps.pl as a Step file, and .*\.feature as a feature file.
@@ -83,8 +83,8 @@ as generated from C<make test> after C<perl Makefile.PL>.
  my ( $executor, @features ) = Test::BDD::Cucumber::Loader->load(
         't/cucumber_core_features/' );
 
- # Create a Harness to execute against. TestBuilder harness prints TAP
- my $harness = Test::BDD::Cucumber::Harness::TestBuilder->new({});
+ # Create a Harness to execute against. TAP harness prints TAP
+ my $harness = Test::BDD::Cucumber::Harness::TAP->new({});
 
  # For each feature found, execute it, using the Harness to print results
  $executor->execute( $_, $harness ) for @features;

--- a/t/400_app_pherkin_harnesses.t
+++ b/t/400_app_pherkin_harnesses.t
@@ -9,7 +9,7 @@ use Test::More;
 my @known_harnesses = (
     "Data",                                       # Short form
     "Test::BDD::Cucumber::Harness::TermColor",    # Long form
-    "Test::BDD::Cucumber::Harness::TestBuilder",
+    "Test::BDD::Cucumber::Harness::TAP",
     "Test::BDD::Cucumber::Harness::JSON"
 );
 

--- a/t/900_run_cucumber_tests.t
+++ b/t/900_run_cucumber_tests.t
@@ -5,9 +5,9 @@ use warnings;
 
 use Test::More;
 use Test::BDD::Cucumber::Loader;
-use Test::BDD::Cucumber::Harness::TestBuilder;
+use Test::BDD::Cucumber::Harness::TAP;
 
-my $harness = Test::BDD::Cucumber::Harness::TestBuilder->new(
+my $harness = Test::BDD::Cucumber::Harness::TAP->new(
     {
         fail_skip => 1
     }

--- a/t/910_run_tests_pherkin.t
+++ b/t/910_run_tests_pherkin.t
@@ -13,7 +13,7 @@ use Test::CucumberExtensionMetadataVerify;
 my $pherkin = App::pherkin->new;
 push @{$pherkin->extensions}, Test::CucumberExtensionMetadataVerify->new;
 subtest 'Run pherkin in match-only mode', sub {
-    $pherkin->run('-oTestBuilder', '-m', 't/pherkin/match-only/');
+    $pherkin->run('-oTAP', '-m', 't/pherkin/match-only/');
 };
 
 done_testing;


### PR DESCRIPTION
Note that the other harnesses are named after their output as well.

Secondly, there's an on-going branch to move from Test::Builder to
Test2 -- meaning that TestBuilder 'bleeds' the implementation method
which we're likely moving away from.