### PR TITLE
Use 'JSON->decode' instead of the legacy 'from_json'

### DIFF
--- a/lib/Test/BDD/Cucumber/I18N/Data.pm
+++ b/lib/Test/BDD/Cucumber/I18N/Data.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 use utf8;
 
-use JSON::MaybeXS qw/from_json/;
+use JSON::MaybeXS qw/JSON/;
 
 =encoding utf8
 
@@ -50,13 +50,13 @@ L<The license on that file/project|https://github.com/cucumber/cucumber/blob/mas
 
 =head2 language_definitions
 
-Load and C<from_json> the language definitions.
+Load and C<decode_json> the language definitions.
 
 =cut
 
 sub language_definitions {
     my $raw = join '', (<DATA>);
-    my $langdefs = from_json($raw);
+    my $langdefs = JSON()->new->decode($raw);
     for my $lang (values %$langdefs) {
        for my $keyword (keys %{$lang}) {
           $lang->{$keyword} = join '|', @{$lang->{$keyword}}


### PR DESCRIPTION
On some CPAN builders, the use of 'from_json' breaks the build as
it's the legacy invocation. Let's use a more modern api.