### PR TITLE
Add strict option

### DIFF
--- a/bin/pherkin
+++ b/bin/pherkin
@@ -38,6 +38,8 @@ Controlling Execution
      --matching [mode]  Step function multiple matches behaviour:
                         `first` (default) selects first match, `relaxed` warns
                         and runs first match or `strict` stops execution
+     --strict           Requires steps to be defined; fails on undefined
+                        and pending steps (steps forcing 'skip')
 
 Output formatting
 
@@ -172,6 +174,4 @@ BEGIN {
     }
 }
 
-my $result = App::pherkin->new()->run(@ARGV);
-
-exit( $result->result eq 'failing' );
+exit App::pherkin->new()->run(@ARGV);

--- a/lib/App/pherkin.pm
+++ b/lib/App/pherkin.pm
@@ -255,17 +255,17 @@ sub _process_arguments {
         debug_profiles => ['debug-profiles'],
 
         # Standard
-        help       => ['h|help|?'],
+        help       => [ 'h|help|?' ],
         includes   => [ 'I=s@', [] ],
-        lib        => ['l|lib'],
-        blib       => ['b|blib'],
-        output     => ['o|output=s'],
+        lib        => [ 'l|lib' ],
+        blib       => [ 'b|blib' ],
+        output     => [ 'o|output=s' ],
         steps      => [ 's|steps=s@', [] ],
         tags       => [ 't|tags=s@', [] ],
-        i18n       => ['i18n=s'],
+        i18n       => [ 'i18n=s' ],
         extensions => [ 'e|extension=s@', [] ],
         matching   => [ 'matching=s' ],
-        match_only => ['m|match'],
+        match_only => [ 'm|match' ],
     );
 
     GetOptions(


### PR DESCRIPTION
At the request of @littlebenlittle, I'm adding the `--strict` option to `pherkin` to make it return a non-zero exit code when any undefined or pending steps exist.