### PR TITLE
Fix #166: Set shebang line to value replaced on 'make install'

### DIFF
--- a/bin/pherkin
+++ b/bin/pherkin
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 
 =head1 NAME
 


### PR DESCRIPTION
As #perl on freenode explained, shebang lines #!perl and #!/usr/bin/perl
will be replaced on 'make install'. The current value was chosen because
it works well with in-tree execution in combination with plenv. Researching
other options to make in-tree execution work with this shebang line and
plenv... For installation, this is a solution though.