### PR TITLE
Allow example variables to be used in Scenario Outline title

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 -----
 
 0.73  2020-08-24
-    [Fixed]
+    [Added]
       - Allow Example variables to be used in Scenario Outline title
 0.72  2020-08-21
     [Fixed]

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 -----
 
-
+0.73  2020-08-24
+    [Fixed]
+      - Allow Example variables to be used in Scenario Outline title
 0.72  2020-08-21
     [Fixed]
       - Shebang of 'pherkin' script not replaced on 'make install' (gh #166)
@@ -318,4 +320,3 @@
     - Various bits of documentation enhancements
 0.02  2011-12-20
       - Added extra docs, and a few tiny bug fixes
-

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name      = Test-BDD-Cucumber
-version   = 0.72
+version   = 0.73
 abstract  = Feature-complete Cucumber-style testing in Perl
 main_module = lib/Test/BDD/Cucumber.pm
 author    = Peter Sergeant <pete@clueball.com>

--- a/lib/Test/BDD/Cucumber/Executor.pm
+++ b/lib/Test/BDD/Cucumber/Executor.pm
@@ -239,13 +239,15 @@ sub execute_outline {
 
 
     foreach my $rows (@datasets) {
+
         my $outline_state = {};
-        my $name = $outline->{name} || "";
 
         foreach my $row (@{$rows->data}) {
 
-            $outline->{name} =~ s/<$_>/$row->{$_}/g
+            my $name = $outline->{name} || "";
+            $name =~ s/<$_>/$row->{$_}/g
                 for (keys %$row);
+            local $outline->{name} = $name;
 
             $self->execute_scenario(
                 {
@@ -260,7 +262,6 @@ sub execute_outline {
                 });
 
             $outline_state->{'short_circuit'} ||= $self->_bail_out;
-            $outline->{name} = $name;
         }
     }
 }

--- a/lib/Test/BDD/Cucumber/Executor.pm
+++ b/lib/Test/BDD/Cucumber/Executor.pm
@@ -240,8 +240,13 @@ sub execute_outline {
 
     foreach my $rows (@datasets) {
         my $outline_state = {};
+        my $name = $outline->{name} || "";
 
         foreach my $row (@{$rows->data}) {
+
+            $outline->{name} =~ s/<$_>/$row->{$_}/g
+                for (keys %$row);
+
             $self->execute_scenario(
                 {
                     feature => $feature,
@@ -255,6 +260,7 @@ sub execute_outline {
                 });
 
             $outline_state->{'short_circuit'} ||= $self->_bail_out;
+            $outline->{name} = $name;
         }
     }
 }

--- a/lib/Test/BDD/Cucumber/Executor.pm
+++ b/lib/Test/BDD/Cucumber/Executor.pm
@@ -245,7 +245,7 @@ sub execute_outline {
         foreach my $row (@{$rows->data}) {
 
             my $name = $outline->{name} || "";
-            $name =~ s/<$_>/$row->{$_}/g
+            $name =~ s/\Q<$_>\E/$row->{$_}/g
                 for (keys %$row);
             local $outline->{name} = $name;
 


### PR DESCRIPTION
Change the Scenario Outline title handling to allow substitution of example variables for each variable.
Simply use the usual <variable> syntax.