### PR TITLE
Fix #165: failure to load T::B::C::StepFile

### DIFF
--- a/lib/Test/BDD/Cucumber/StepFile.pm
+++ b/lib/Test/BDD/Cucumber/StepFile.pm
@@ -123,6 +123,7 @@ sub _alias_function {
         next if $word eq '*';
 
         my $subname = keyword_to_subname($word);
+        next unless length $subname;
 
         {
             no strict 'refs';


### PR DESCRIPTION
With a lot of help from #perl on freenode.org, which established that the
emoticons aren't word-characters and also not valid sub names and thus
returns empty-string $subname values, which in turn causes the glob of the
main package to be modified instead of a function in it.