### PR TITLE
Make sure to exchange utf8 data in `prove` plugin

### DIFF
--- a/lib/TAP/Parser/SourceHandler/Feature.pm
+++ b/lib/TAP/Parser/SourceHandler/Feature.pm
@@ -84,9 +84,11 @@ sub make_iterator {
 
     my ( $input_out_fh, $output_out_fh );
     pipe $input_out_fh, $output_out_fh;
+    binmode $output_out_fh, ':utf8';
 
     my ( $input_err_fh, $output_err_fh );
     pipe $input_err_fh, $output_err_fh;
+    binmode $output_err_fh, ':utf8';
 
     # Don't cache the output so prove sees it immediately
     #  (pipes are stdio buffered by default)


### PR DESCRIPTION
With @ylavoie, make sure the prove plugin exchanges in-memory utf8
data correctly encoded and decoded over the two sides of the pipe.

Also make sure this encoding does not just apply to STDOUT, but also
to STDERR.