### PR TITLE
Eliminate UTF-8 warnings while formatting test output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,15 @@ jobs:
   build:
     name: Continuous Integration
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        perl: ['5.10', '5.14', '5.16', '5.18', '5.20', '5.22', '5.24', '5.26', '5.28', '5.30']
     steps:
     - uses: actions/checkout@v2
     - uses: shogo82148/actions-setup-perl@v1
       with:
-        perl-version: '5.32'
+        perl-version: ${{ matrix.perl }}
     - run: cpanm --notest Dist::Zilla
     - run: dzil authordeps --missing | cpanm --notest
     - run: dzil listdeps --missing | cpanm --notest

--- a/lib/Test/BDD/Cucumber/Executor.pm
+++ b/lib/Test/BDD/Cucumber/Executor.pm
@@ -697,7 +697,7 @@ sub _extract_match_strings {
 sub _test_output {
     my ($self, $events) = @_;
     my $fmt = Test2::Formatter::TAP->new();
-    open my $stdout, '>', \my $out_text;
+    open my $stdout, '>:encoding(UTF-8)', \my $out_text;
     my $idx = 0;
 
     $fmt->set_handles([ $stdout, $stdout ]);


### PR DESCRIPTION
This solves a long-standing warning in the LedgerSMB project where
test output includes a checkmark (utf8 character U+2713). While
perfectly valid UTF-8 and the data never leaves the application
memory space, the error has been puzzling thusfar. With help from
@ylavioe, it's now sorted that this fix solves the warning.