### PR TITLE
Remove mention of `use_ok`

### DIFF
--- a/lib/Test/BDD/Cucumber/Manual/Tutorial.pod
+++ b/lib/Test/BDD/Cucumber/Manual/Tutorial.pod
@@ -68,7 +68,7 @@ C<features/step_definitions/basic_steps.pl> file in it:
  use Test2::Bundle::More;
  use Test::BDD::Cucumber::StepFile;
 
- Given qr/a usable (\S+) class/, sub { use_ok( $1 ); };
+ Given qr/a usable (\S+) class/, sub { eval "use $1;" };
  Given qr/a Digest (\S+) object/, sub {
     my $object = Digest->new($1);
     ok( $object, "Object created" );


### PR DESCRIPTION
Test2::Bundle::More doesn't contain `use_ok`; it's one of the (few)
things Test2 doesn't have that Test::More did.

Fixes #190.